### PR TITLE
chore: dynamically fetch charm name from metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/canonical/pebble v1.20.0
-	github.com/gruyaume/goops v0.0.10
+	github.com/gruyaume/goops v0.0.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/canonical/pebble v1.20.0 h1:uzV42R3AfxL+oM75ScUHrGOnDCft5dmLvcwbOsLi2
 github.com/canonical/pebble v1.20.0/go.mod h1:4FuafBIWiGSLrvzlqtVrH+p94Anm5Qj5qElptozMZG8=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/gruyaume/goops v0.0.10 h1:Voyh64iBmWCenLHG9GUagk+fyigSmxqyyfyydkUyPEQ=
-github.com/gruyaume/goops v0.0.10/go.mod h1:Ix0041QiQNrAVMiTRZCUtuApl2CskrGtru3HYKZhCfE=
+github.com/gruyaume/goops v0.0.11 h1:OK7elw0mhJsRK2c+P32xXw0LwyA93Fch393jCHA0xnU=
+github.com/gruyaume/goops v0.0.11/go.mod h1:91Pt2hUN92i9M74tYVJ1ASmCXV+5UtAnMGKlQmz/21g=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/pebble/client"
 	"github.com/gruyaume/goops"
 	"github.com/gruyaume/goops/commands"
+	"github.com/gruyaume/goops/metadata"
 	"github.com/gruyaume/notary-k8s/integrations/prometheus"
 	"github.com/gruyaume/notary-k8s/internal/notary"
 )
@@ -54,10 +55,16 @@ func HandleDefaultHook(hookContext *goops.HookContext) {
 		return
 	}
 
+	metadata, err := metadata.GetCharmMetadata(hookContext.Environment)
+	if err != nil {
+		hookContext.Commands.JujuLog(commands.Error, "Could not get charm metadata:", err.Error())
+		return
+	}
+
 	prometheusIntegration := &prometheus.Integration{
 		HookContext:  hookContext,
 		RelationName: MetricsIntegrationName,
-		CharmName:    "notary-k8s",
+		CharmName:    metadata.Name,
 		Jobs: []*prometheus.Job{
 			{
 				Scheme:      "https",


### PR DESCRIPTION
# Description

Use the newly added feature in `goops` to get the charm metadata and use it to use the charm name. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
