### PR TITLE
feat: add tls provides integration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -45,9 +45,13 @@ resources:
     upstream-source: ghcr.io/canonical/notary:0.0.3
 
 provides:
+  certificates:
+    interface: tls-certificates
   metrics:
     interface: prometheus_scrape
 
 requires:
-  certificates:
+  access-certificates:
+    limit: 1
     interface: tls-certificates
+    optional: true

--- a/integrations/certificates/provider.go
+++ b/integrations/certificates/provider.go
@@ -1,0 +1,76 @@
+package certificates
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gruyaume/goops"
+	"github.com/gruyaume/goops/commands"
+)
+
+type IntegrationProvider struct {
+	HookContext  *goops.HookContext
+	RelationName string
+}
+
+type RequirerCertificateSigningRequests struct {
+	CA                        string `json:"ca"`
+	CertificateSigningRequest string `json:"certificate_signing_request"`
+}
+
+func (i *IntegrationProvider) GetRelationID() (string, error) {
+	relationIDs, err := i.HookContext.Commands.RelationIDs(&commands.RelationIDsOptions{
+		Name: i.RelationName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not get relation IDs: %w", err)
+	}
+
+	if len(relationIDs) == 0 {
+		return "", fmt.Errorf("no relation IDs found for %s", i.RelationName)
+	}
+
+	return relationIDs[0], nil
+}
+
+func (i *IntegrationProvider) GetCertificateRequests() ([]*RequirerCertificateSigningRequests, error) {
+	relationID, err := i.GetRelationID()
+	if err != nil {
+		i.HookContext.Commands.JujuLog(commands.Warning, "Could not get relation ID", err.Error())
+		return nil, err
+	}
+
+	relations, err := i.HookContext.Commands.RelationList(&commands.RelationListOptions{
+		ID: relationID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not list relations for ID %s: %v", relationID, err)
+	}
+
+	if len(relations) == 0 {
+		return nil, fmt.Errorf("no relations found for ID %s", relationID)
+	}
+
+	relationData, err := i.HookContext.Commands.RelationGet(&commands.RelationGetOptions{
+		ID:     relationID,
+		UnitID: relations[0],
+		App:    true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not get relation data: %w", err)
+	}
+
+	requestsStr := relationData["certificate_signing_requests"]
+	if requestsStr == "" {
+		return nil, fmt.Errorf("no request found in relation data")
+	}
+
+	var requirerCertificateSigningRequests []*RequirerCertificateSigningRequests
+
+	err = json.Unmarshal([]byte(requestsStr), &requirerCertificateSigningRequests)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal requirer requests: %w", err)
+	}
+
+	return requirerCertificateSigningRequests, nil
+}

--- a/integrations/certificates/requirer.go
+++ b/integrations/certificates/requirer.go
@@ -35,13 +35,20 @@ type CertificateRequestAttributes struct {
 	LocalityName        string
 }
 
-type Integration struct {
+type IntegrationRequirer struct {
 	HookContext        *goops.HookContext
 	RelationName       string
 	CertificateRequest CertificateRequestAttributes
 }
 
-func (i *Integration) GetRelationID() (string, error) {
+type ProviderCertificate struct {
+	CA                        string   `json:"ca"`
+	Chain                     []string `json:"chain"`
+	CertificateSigningRequest string   `json:"certificate_signing_request"`
+	Certificate               string   `json:"certificate"`
+}
+
+func (i *IntegrationRequirer) GetRelationID() (string, error) {
 	relationIDs, err := i.HookContext.Commands.RelationIDs(&commands.RelationIDsOptions{
 		Name: i.RelationName,
 	})
@@ -56,7 +63,7 @@ func (i *Integration) GetRelationID() (string, error) {
 	return relationIDs[0], nil
 }
 
-func (i *Integration) Request() error {
+func (i *IntegrationRequirer) Request() error {
 	relationID, err := i.GetRelationID()
 	if err != nil {
 		return fmt.Errorf("could not get relation ID: %v", err)
@@ -105,7 +112,7 @@ func (i *Integration) Request() error {
 	return nil
 }
 
-func (i *Integration) certificateRequested() bool {
+func (i *IntegrationRequirer) certificateRequested() bool {
 	relationID, err := i.GetRelationID()
 	if err != nil {
 		i.HookContext.Commands.JujuLog(commands.Warning, "Could not get relation ID", err.Error())
@@ -182,14 +189,7 @@ func (i *Integration) certificateRequested() bool {
 	return err == nil
 }
 
-type ProviderCertificate struct {
-	CA                        string   `json:"ca"`
-	Chain                     []string `json:"chain"`
-	CertificateSigningRequest string   `json:"certificate_signing_request"`
-	Certificate               string   `json:"certificate"`
-}
-
-func (i *Integration) GetProviderCertificate() ([]*ProviderCertificate, error) {
+func (i *IntegrationRequirer) GetProviderCertificate() ([]*ProviderCertificate, error) {
 	relationID, err := i.GetRelationID()
 	if err != nil {
 		return nil, fmt.Errorf("could not get relation ID: %v", err)
@@ -234,7 +234,7 @@ func (i *Integration) GetProviderCertificate() ([]*ProviderCertificate, error) {
 	return providerCertificate, nil
 }
 
-func (i *Integration) GetPrivateKey() (string, error) {
+func (i *IntegrationRequirer) GetPrivateKey() (string, error) {
 	secret, err := i.HookContext.Commands.SecretGet(&commands.SecretGetOptions{
 		Label:   PrivateKeySecretLabel,
 		Refresh: true,
@@ -250,7 +250,7 @@ func (i *Integration) GetPrivateKey() (string, error) {
 	return secret["private-key"], nil
 }
 
-func (i *Integration) getOrGeneratePrivateKey() (string, error) {
+func (i *IntegrationRequirer) getOrGeneratePrivateKey() (string, error) {
 	secret, _ := i.HookContext.Commands.SecretGet(&commands.SecretGetOptions{
 		Label:   PrivateKeySecretLabel,
 		Refresh: true,
@@ -292,7 +292,7 @@ func (i *Integration) getOrGeneratePrivateKey() (string, error) {
 	return keyBuf.String(), nil
 }
 
-func (i *Integration) generateCSR(privateKeyPEM string) (string, error) {
+func (i *IntegrationRequirer) generateCSR(privateKeyPEM string) (string, error) {
 	block, _ := pem.Decode([]byte(privateKeyPEM))
 	if block == nil {
 		return "", fmt.Errorf("failed to PEM decode private key")

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -17,14 +17,15 @@ import (
 )
 
 const (
-	KeyPath                = "/etc/notary/config/key.pem"
-	CertPath               = "/etc/notary/config/cert.pem"
-	ConfigPath             = "/etc/notary/config/notary.yaml"
-	APIPort                = 2111
-	CharmAccountUsername   = "charm@notary.com"
-	NotaryLoginSecretLabel = "NOTARY_LOGIN"
-	MetricsIntegrationName = "metrics"
-	TLSIntegrationName     = "certificates"
+	KeyPath                    = "/etc/notary/config/key.pem"
+	CertPath                   = "/etc/notary/config/cert.pem"
+	ConfigPath                 = "/etc/notary/config/notary.yaml"
+	APIPort                    = 2111
+	CharmAccountUsername       = "charm@notary.com"
+	NotaryLoginSecretLabel     = "NOTARY_LOGIN"
+	MetricsIntegrationName     = "metrics"
+	TLSRequiresIntegrationName = "access-certificates"
+	TLSProvidesIntegrationName = "certificates"
 )
 
 func setPorts(hookContext *goops.HookContext) error {
@@ -164,11 +165,42 @@ func HandleDefaultHook(hookContext *goops.HookContext) {
 	}
 
 	hookContext.Commands.JujuLog(commands.Info, "Admin account created")
+
+	err = syncCertificatesProvides(hookContext)
+	if err != nil {
+		hookContext.Commands.JujuLog(commands.Error, "Could not sync certificates provides:", err.Error())
+		return
+	}
+
+	hookContext.Commands.JujuLog(commands.Info, "Certificates provider synced")
 }
 
-func tlsIntegrationCreated(hookContext *goops.HookContext) bool {
+// syncCertificatesProvides provides TLS certificates to TLS requirers
+func syncCertificatesProvides(hookContext *goops.HookContext) error {
+	if !integrationCreated(hookContext, TLSProvidesIntegrationName) {
+		return nil
+	}
+
+	tlsProviderIntegration := certificates.IntegrationProvider{
+		HookContext:  hookContext,
+		RelationName: TLSRequiresIntegrationName,
+	}
+
+	certRequests, err := tlsProviderIntegration.GetCertificateRequests()
+	if err != nil {
+		return fmt.Errorf("could not get certificate requests: %w", err)
+	}
+
+	for _, certRequest := range certRequests {
+		hookContext.Commands.JujuLog(commands.Info, "Certificate request:", certRequest.CertificateSigningRequest)
+	}
+
+	return nil
+}
+
+func integrationCreated(hookContext *goops.HookContext, name string) bool {
 	relationIDs, err := hookContext.Commands.RelationIDs(&commands.RelationIDsOptions{
-		Name: TLSIntegrationName,
+		Name: name,
 	})
 	if err != nil {
 		return false
@@ -213,11 +245,13 @@ func syncSelfSignedCertificate(hookContext *goops.HookContext, pebble *client.Cl
 	return true, nil
 }
 
+// syncTlsProviderCertificate makes a certificate request to the TLS provider
+// and pushes the certificate and key to the pebble client.
 func syncTlsProviderCertificate(hookContext *goops.HookContext, pebble *client.Client) (bool, error) {
 	changed := false
-	tlsIntegration := certificates.Integration{
+	tlsRequirerIntegration := certificates.IntegrationRequirer{
 		HookContext:  hookContext,
-		RelationName: TLSIntegrationName,
+		RelationName: TLSRequiresIntegrationName,
 		CertificateRequest: certificates.CertificateRequestAttributes{
 			CommonName:          getHostname(hookContext),
 			SansDNS:             []string{getHostname(hookContext)},
@@ -228,14 +262,14 @@ func syncTlsProviderCertificate(hookContext *goops.HookContext, pebble *client.C
 		},
 	}
 
-	err := tlsIntegration.Request()
+	err := tlsRequirerIntegration.Request()
 	if err != nil {
 		return changed, fmt.Errorf("could not request certificate: %w", err)
 	}
 
 	hookContext.Commands.JujuLog(commands.Info, "Certificate requested")
 
-	providerCert, err := tlsIntegration.GetProviderCertificate()
+	providerCert, err := tlsRequirerIntegration.GetProviderCertificate()
 	if err != nil {
 		return changed, fmt.Errorf("could not get certificate: %w", err)
 	}
@@ -250,7 +284,7 @@ func syncTlsProviderCertificate(hookContext *goops.HookContext, pebble *client.C
 
 	hookContext.Commands.JujuLog(commands.Info, "Certificate received")
 
-	privateKey, err := tlsIntegration.GetPrivateKey()
+	privateKey, err := tlsRequirerIntegration.GetPrivateKey()
 	if err != nil {
 		return changed, fmt.Errorf("could not get private key: %w", err)
 	}
@@ -292,7 +326,7 @@ func syncCertificate(hookContext *goops.HookContext, pebble *client.Client) (boo
 
 	var err error
 
-	if !tlsIntegrationCreated(hookContext) {
+	if !integrationCreated(hookContext, TLSRequiresIntegrationName) {
 		hookContext.Commands.JujuLog(commands.Info, "TLS integration not created")
 
 		changed, err = syncSelfSignedCertificate(hookContext, pebble)


### PR DESCRIPTION
# Description

Add tls provides integration:

**Add certificate request to Notary**
- [ ] Get list of csrs from databag
- [ ] Get list of csrs in Notary
- [ ] If the csr isn't in notary, create cert request there

**Provide Notary issued certificate to tls requirer**
- [ ] Get list of csrs from databag
- [ ] Get list of csrs from Notary
- [ ] If a certificate is issued for a CSR in Notary, add it to the relation

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
